### PR TITLE
Fix multi-node support

### DIFF
--- a/3.11/windows.yml
+++ b/3.11/windows.yml
@@ -41,9 +41,6 @@
     k_dir_path: C:\k
     openvswitch_installer_url: https://cloudbase.it/downloads/openvswitch-hyperv-installer-beta.msi
     openshift_windows_git_url: https://github.com/glennswest/openshift-windows
-    ovs_subnet: "10.128.1.0/24"
-    ovs_gateway: "10.128.1.1"
-    ovs_network_name: "external"
   tasks:
   - name: Windows | Setup all the Windows machines prerequisites (this may take a while)
     win_shell: |
@@ -219,75 +216,6 @@
     win_service:
       name: ovsdb-server
       state: started
-  - name: Windows | Prepare Windows scheduled tasks for the SDN setup
-    win_scheduled_task:
-      name: "setup_sdn"
-      executable: powershell.exe
-      arguments: >
-        -ExecutionPolicy Unrestricted -NonInteractive -Command
-        "& '{{ k_dir_path }}\hybrid\3.11\bin\setup_sdn.ps1' -OVSNetworkName {{ ovs_network_name }}
-        -OVSSubnet {{ ovs_subnet }} -OVSGateway {{ ovs_gateway }}
-        2>&1 > '{{ k_dir_path }}\hybrid\3.11\bin\setup_sdn.log';
-        Write-Output $LASTEXITCODE > {{ k_dir_path }}\hybrid\3.11\bin\setup_sdn.status"
-      frequency: once
-      enabled: true
-      time: "00:00:00"
-      user: SYSTEM
-  - name: Windows | Setup Windows SDN
-    win_shell: Start-ScheduledTask -TaskName "setup_sdn"
-  - name: Windows | Wait for Windows SDN setup
-    wait_for_connection:
-      # Allow 60 seconds for the setup_sdn task to finish. Connection will
-      # temporarily drop during this period of time.
-      delay: 60
-      # Maximum of 10 minutes allowed timeout.
-      timeout: 600
-  - name: Windows | Check Windows SDN setup task
-    win_shell: |
-      $ErrorActionPreference = "Stop"
-      $taskName = "setup_sdn"
-      if((Get-ScheduledTask -TaskName $taskName).State -ne 'Ready') {
-          Throw "The scheduled task $taskName is not ready"
-      }
-      Write-Output "The scheduled task is ready"
-      $statusFile = "{{ k_dir_path }}\hybrid\3.11\bin\${taskName}.status"
-      if(!(Test-Path $statusFile)) {
-          Write-Output "Status file doesn't exist. Skipping"
-          exit 0
-      }
-      $exitCode = Get-Content $statusFile
-      if($exitCode -ne 0) {
-          Throw "Scheduled task ${taskName} returned with error"
-      }
-      Write-Output "Scheduled task ${taskName} returned with success"
-  - name: Windows | Clean up Windows SDN setup task
-    win_scheduled_task:
-      name: "setup_sdn"
-      state: absent
-  - name: Windows | Restart the Docker service
-    win_service:
-      name: Docker
-      state: restarted
-  - name: Windows | Check if the HNS network for OVS is available in the Docker API
-    win_shell: |
-      $ErrorActionPreference = "Stop"
-      $net = docker.exe network ls --quiet --filter name={{ ovs_network_name }} --filter driver=transparent
-      if($LASTEXITCODE) {
-          Throw "Failed to list the Docker networks"
-      }
-      if(!$net) {
-          Throw "The HNS network for OVS is not available in the Docker API"
-      }
-  - name: Pull down windowsservercore 1803 (Note this may take a long time)
-    win_shell: docker pull microsoft/windowsservercore:1803
-    async: 50000
-    poll: 5
-  - name: Tag The image
-    win_shell: docker tag microsoft/windowsservercore:1803 microsoft/windowsservercore:latest
-  - name: Build the pause windows container
-    win_shell: docker build . -t kubeletwin/pause
-    args:
-      chdir: '{{ k_dir_path }}\hybrid\3.11'
 - hosts: windows
   gather_facts: no
   serial: 1
@@ -429,6 +357,81 @@
     win_shell: "[System.Environment]::SetEnvironmentVariable('KUBECONFIG', 'c:/k/config;c:/k/system-node-1.masters | first }}.kubeconfig', [System.EnvironmentVariableTarget]::Machine)"
   - name: Set kubeconfig
     win_shell: "[System.Environment]::SetEnvironmentVariable('KUBECONFIG', 'c:/k/config;c:/k/system-node-{{ groups.masters | first }}.kubeconfig')"
+- hosts: windows
+  gather_facts: no
+  vars:
+    user: "{{lookup('env','USER')}}"
+    k_dir_path: C:\k
+    ovs_network_name: "external"
+  tasks:
+  - name: Windows | Prepare Windows scheduled tasks for the SDN setup
+    win_scheduled_task:
+      name: "setup_sdn"
+      executable: powershell.exe
+      arguments: >
+        -ExecutionPolicy Unrestricted -NonInteractive -Command
+        "& '{{ k_dir_path }}\hybrid\3.11\bin\setup_sdn.ps1' -OVSNetworkName {{ ovs_network_name }}
+        -SubnetFile {{ k_dir_path }}\host.subnet 2>&1 > '{{ k_dir_path }}\hybrid\3.11\bin\setup_sdn.log';
+        Write-Output $LASTEXITCODE > {{ k_dir_path }}\hybrid\3.11\bin\setup_sdn.status"
+      frequency: once
+      enabled: true
+      time: "00:00:00"
+      user: SYSTEM
+  - name: Windows | Setup Windows SDN
+    win_shell: Start-ScheduledTask -TaskName "setup_sdn"
+  - name: Windows | Wait for Windows SDN setup
+    wait_for_connection:
+      # Allow 60 seconds for the setup_sdn task to finish. Connection will
+      # temporarily drop during this period of time.
+      delay: 60
+      # Maximum of 10 minutes allowed timeout.
+      timeout: 600
+  - name: Windows | Check Windows SDN setup task
+    win_shell: |
+      $ErrorActionPreference = "Stop"
+      $taskName = "setup_sdn"
+      if((Get-ScheduledTask -TaskName $taskName).State -ne 'Ready') {
+          Throw "The scheduled task $taskName is not ready"
+      }
+      Write-Output "The scheduled task is ready"
+      $statusFile = "{{ k_dir_path }}\hybrid\3.11\bin\${taskName}.status"
+      if(!(Test-Path $statusFile)) {
+          Write-Output "Status file doesn't exist. Skipping"
+          exit 0
+      }
+      $exitCode = Get-Content $statusFile
+      if($exitCode -ne 0) {
+          Throw "Scheduled task ${taskName} returned with error"
+      }
+      Write-Output "Scheduled task ${taskName} returned with success"
+  - name: Windows | Clean up Windows SDN setup task
+    win_scheduled_task:
+      name: "setup_sdn"
+      state: absent
+  - name: Windows | Restart the Docker service
+    win_service:
+      name: Docker
+      state: restarted
+  - name: Windows | Check if the HNS network for OVS is available in the Docker API
+    win_shell: |
+      $ErrorActionPreference = "Stop"
+      $net = docker.exe network ls --quiet --filter name={{ ovs_network_name }} --filter driver=transparent
+      if($LASTEXITCODE) {
+          Throw "Failed to list the Docker networks"
+      }
+      if(!$net) {
+          Throw "The HNS network for OVS is not available in the Docker API"
+      }
+  - name: Pull down windowsservercore 1803 (Note this may take a long time)
+    win_shell: docker pull microsoft/windowsservercore:1803
+    async: 50000
+    poll: 5
+  - name: Tag The image
+    win_shell: docker tag microsoft/windowsservercore:1803 microsoft/windowsservercore:latest
+  - name: Build the pause windows container
+    win_shell: docker build . -t kubeletwin/pause
+    args:
+      chdir: '{{ k_dir_path }}\hybrid\3.11'
 # Part 2
 - hosts: windows
   serial: 1

--- a/3.11/windows.yml
+++ b/3.11/windows.yml
@@ -159,15 +159,15 @@
     with_items:
       - '${env:ProgramData}\chocolatey\bin'
       - "{{ bin_dir_path }}"
-  - name: Windows | Install 7-Zip Git and Curl
-    win_shell: choco install {{ item }} -y
-    with_items:
-      - "7zip.portable"
-      - "git"
-      - "curl"
-      - "nssm"
+  - name: Windows | Install nssm
+    win_shell: choco install nssm -y
     retries: 5
     delay: 5
+  - name: Windows | Install Vim (potential failures will be ignored since this is non-critical)
+    win_shell: choco install vim -y
+    retries: 5
+    delay: 5
+    ignore_errors: yes
   - name: Windows | Pull down Hybrid Git directory in zip format
     win_shell: curl.exe -L -k {{ openshift_windows_git_url }}/archive/master.zip -o $env:TEMP\openshift-windows.zip
     retries: 5


### PR DESCRIPTION
The general cleanup for the Windows ansible playbooks omitted up the network using the information from the local .subnet` file.

This required the setup_sdn.ps1 step to be moved into its previous in the playbook in order to have the file host.subnet already before execution.